### PR TITLE
Disable the CFP

### DIFF
--- a/now.json
+++ b/now.json
@@ -4,6 +4,10 @@
   "alias": ["webconf.tech", "www.webconf.tech"],
   "redirects": [
     {
+      "source": "/cfp",
+      "destination": "/"
+    },
+    {
       "source": "/cfp-form",
       "destination": "https://forms.gle/9gTiyXQC6oLRsP3u7"
     },

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Head from 'next/head';
-import Link from 'next/link';
 import styled from 'styled-components';
 import { transparentize } from 'polished';
 import { BREAKPOINTS, COLORS } from '../style/constants';
@@ -245,7 +244,7 @@ const Home = () => {
         <EventCountdown />
       </TimerSection>
       <ActionsSection>
-        <Action>
+        {/* <Action>
           <Link href="/cfp">
             <LilacButton href="/cfp" color="primary-light" shadow>
               <ActionText>
@@ -256,8 +255,7 @@ const Home = () => {
           <ActionDate>
             Hasta el 31/03
           </ActionDate>
-        </Action>
-        {/* <Action>
+        </Action><Action>
           <Link href="/">
             <LilacButton href="/" color="accent" shadow>
               <ActionText>


### PR DESCRIPTION
- I removed the link from the home page (the `Link` import I removed was to avoid ESLint issues because it was unused).
- I modified the Now config so the route `/cfp` would redirect to the home. @asermax I don't know if there's a better way to do it with Next, the one I found was an early return of the home component on the cfp page... and I didn't like it :P.